### PR TITLE
Delete teams

### DIFF
--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -18,6 +18,17 @@ CREATE TABLE IF NOT EXISTS `team` (
   UNIQUE INDEX `name_unique` (`name` ASC));
 
 -- -----------------------------------------------------
+-- Table `deleted_teams`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `deleted_teams` (
+  `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `new_name` VARCHAR(255) NOT NULL,
+  `old_name` VARCHAR(255) NOT NULL,
+  `deletion_date` DATE NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `new_name_unique` (`new_name` ASC));
+
+-- -----------------------------------------------------
 -- Table `user`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `user` (

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -1,6 +1,7 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
-
+import uuid
+import datetime
 from urllib import unquote
 from falcon import HTTPNotFound, HTTPBadRequest, HTTPError
 from ujson import dumps as json_dumps
@@ -244,6 +245,8 @@ def on_delete(req, resp, team):
     :statuscode 404: Team not found
     '''
     team = unquote(team)
+    new_team = team + '-' + str(uuid.uuid1())
+    deletion_date = datetime.datetime.today().strftime('%Y-%m-%d')
     check_team_auth(team, req)
     connection = db.connect()
     cursor = connection.cursor()
@@ -253,6 +256,14 @@ def on_delete(req, resp, team):
                    'AND `start` > UNIX_TIMESTAMP()', team)
     create_audit({}, team, TEAM_DELETED, req, cursor)
     deleted = cursor.rowcount
+
+    # keep new team name under 255 characters
+    if len(team) > 216:
+        new_team = team[:-38] + '-' + str(uuid.uuid1())
+
+    # create entry in deleted_teams and then change name in team to preserve a clean namespace
+    cursor.execute('UPDATE `team` SET `name` = %s WHERE `name`= %s', (new_team, team))
+    cursor.execute('INSERT INTO `deleted_teams` (new_name, old_name, deletion_date) VALUES (%s, %s, %s)', (new_team, team, deletion_date))
     connection.commit()
     cursor.close()
     connection.close()

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -259,7 +259,7 @@ def on_delete(req, resp, team):
 
     # keep new team name under 255 characters
     if len(team) > 216:
-        new_team = team[:-38] + '-' + str(uuid.uuid1())
+        new_team = team[:216] + '-' + str(uuid.uuid1())
 
     # create entry in deleted_teams and then change name in team to preserve a clean namespace
     cursor.execute('UPDATE `team` SET `name` = %s WHERE `name`= %s', (new_team, team))


### PR DESCRIPTION
When teams are deleted change their names to avoid future namespace conflict. Add new table to keep track of changes for auditing.