### PR TITLE
Vacation propagate

### DIFF
--- a/src/oncall/api/v0/preview.py
+++ b/src/oncall/api/v0/preview.py
@@ -2,7 +2,6 @@
 # See LICENSE in the project root for license information.
 
 from ... import db
-from ...auth import check_team_auth
 from schedules import get_schedules
 from falcon import HTTPNotFound
 from oncall.bin.scheduler import load_scheduler

--- a/src/oncall/api/v0/preview.py
+++ b/src/oncall/api/v0/preview.py
@@ -26,7 +26,6 @@ def on_get(req, resp, schedule_id):
     scheduler_name = cursor.fetchone()['name']
     scheduler = load_scheduler(scheduler_name)
     schedule = get_schedules({'id': schedule_id})[0]
-    check_team_auth(schedule['team'], req)
 
     start__lt = req.get_param('start__lt', required=True)
     end__ge = req.get_param('end__ge', required=True)

--- a/src/oncall/api/v0/preview.py
+++ b/src/oncall/api/v0/preview.py
@@ -29,8 +29,19 @@ def on_get(req, resp, schedule_id):
     start__lt = req.get_param('start__lt', required=True)
     end__ge = req.get_param('end__ge', required=True)
     team__eq = req.get_param('team__eq', required=True)
+    roster_id = schedule['roster_id']
 
-    cursor.execute('CREATE TEMPORARY TABLE IF NOT EXISTS `temp_event` AS (SELECT * FROM `event` WHERE `start` < %s AND `end` > %s)', (start__lt, end__ge))
+    # create a temporary table with the events that include members of the team's roster
+    query = '''
+            CREATE TEMPORARY TABLE IF NOT EXISTS `temp_event` AS
+            (SELECT `event`.*
+            FROM `event`
+            INNER JOIN `roster_user`
+            ON `event`.`user_id`=`roster_user`.`user_id`
+            WHERE `roster_user`.`roster_id`=%s)
+        '''
+
+    cursor.execute(query, roster_id)
 
     scheduler.populate(schedule, start_time, (connection, cursor), table_name)
     resp.body = scheduler.build_preview_response(cursor, start__lt, end__ge, team__eq, table_name)

--- a/src/oncall/scheduler/default.py
+++ b/src/oncall/scheduler/default.py
@@ -90,7 +90,7 @@ class Scheduler(object):
 
         query = '''
                 SELECT DISTINCT `user_id` FROM `%s`
-                WHERE `user_id` in %%s AND (%s) AND (%s)
+                WHERE `user_id` in %%s AND (%s) AND (%s or `role_id`=5)
                 ''' % (table_name, ' OR '.join(range_check), ' OR '.join(team_check))
 
         cursor.execute(query, query_params)

--- a/src/oncall/ui/static/js/incalendar.js
+++ b/src/oncall/ui/static/js/incalendar.js
@@ -46,6 +46,9 @@
           onEventGet: function (data, $calendar) {
             // callback for when fetch events ajax call is completed. list of events from server is passed in as arg
           },
+          onEventAlways: function(){
+            // callback for when fetch events ajax call is completed run regardless of success or failure
+          },
           onAddEvents: function (events) {
             // callback for when events are added to calendar
           },
@@ -678,6 +681,7 @@
         self.options.onEventGet(data, self.$calendar);
       }).always(function(){
         self.$el.removeClass('loading-events');
+        self.options.onEventAlways();
       });
     },
     addCalendarEvents: function (eventsArray) {

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -2237,7 +2237,7 @@ var oncall = {
 
           if ( isNaN(Date.parse(date)) ) {
             oncall.alerts.createAlert('Invalid date.', 'danger', $modal.find('.modal-body'));
-          } else if (date < new Date()) {
+          } else if (date <= new Date()) {
             oncall.alerts.createAlert('Invalid date. Can only preview events in the future.', 'danger', $modal.find('.modal-body'));
           } else {
             self.populatePreview(date.valueOf(), $(this), $modal);

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -2237,6 +2237,8 @@ var oncall = {
 
           if ( isNaN(Date.parse(date)) ) {
             oncall.alerts.createAlert('Invalid date.', 'danger', $modal.find('.modal-body'));
+          } else if (date < new Date()) {
+            oncall.alerts.createAlert('Invalid date. Can only preview events in the future.', 'danger', $modal.find('.modal-body'));
           } else {
             self.populatePreview(date.valueOf(), $(this), $modal);
           }

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -2292,6 +2292,8 @@ var oncall = {
           readOnly: true,
           onEventGet: function(events, $cal){
             $cal.find('[data-schedule-id="' + scheduleId + '"]').attr('data-highlighted', true);
+          },
+          onEventAlways: function(){
             $cta.removeClass('loading disabled').prop('disabled', false);
           }
         });


### PR DESCRIPTION
- a vacation event will now make a user unavailable across all the teams he is part off, even if that vacation event is only in one teams calendar

- temporary table now only copies events that involve members of in the schedule's roster